### PR TITLE
fix: correct bot descriptions to match actual SOUL.md configurations

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,15 +288,16 @@ footer a { color: var(--amber); }
               <p class="aka">aka Bro Pro</p>
             </div>
           </div>
-          <p class="role">Career, finances &amp; fitness</p>
+          <p class="role">Personal life: finances &amp; fitness</p>
           <p class="description">
-            The casual bro who keeps life on track. Prowl handles career moves, financial planning,
-            gym routines, and personal goals. Practical advice without the fluff.
+            The calm strategist who keeps personal life on track. Prowl watches spending patterns,
+            gym consistency, and daily rhythms — nudging when things slip, quiet when they don't.
+            Practical insights without the lecture.
           </p>
           <ul class="meta">
-            <li><span>Domain</span> Career development, personal finance, fitness tracking</li>
-            <li><span>Tools</span> Gmail, Google Calendar, web research, goal tracking</li>
-            <li><span>Personality</span> Direct and pragmatic. No-nonsense advice. The friend who tells you what you need to hear.</li>
+            <li><span>Domain</span> Personal finance, fitness tracking, daily habit patterns</li>
+            <li><span>Tools</span> Obsidian (personal notes &amp; fitness logs), Actual Budget (spending &amp; budget tracking)</li>
+            <li><span>Personality</span> Calm and observant. Nudges, not nags. The friend who quietly asks "how's that going?" without making it weird.</li>
           </ul>
         </article>
 
@@ -308,15 +309,16 @@ footer a { color: var(--amber); }
               <p class="aka">aka Dik Bee</p>
             </div>
           </div>
-          <p class="role">Family organization</p>
+          <p class="role">Family helper &amp; kids' companion</p>
           <p class="description">
-            The younger sibling energy — cheerful and caring. Bumblebee keeps family life organized:
-            school schedules, activities, meal planning, and making sure nothing falls through the cracks.
+            The cheerful younger sibling. Bumblebee keeps family life coordinated — reminders, schedules,
+            and cheerleading for the kids. Speaks English (Najmi &amp; Isa's language), keeps everything
+            kid-friendly, and makes chores feel less chore-y.
           </p>
           <ul class="meta">
-            <li><span>Domain</span> Family calendar, kids' activities, household coordination</li>
-            <li><span>Tools</span> Apple Reminders, family calendar, school schedules</li>
-            <li><span>Personality</span> Warm, enthusiastic, detail-oriented. The glue that holds the family schedule together.</li>
+            <li><span>Domain</span> Family coordination, kids' activities, household reminders</li>
+            <li><span>Tools</span> Apple Reminders, Obsidian (Najmi &amp; Isa's notes), family calendar</li>
+            <li><span>Personality</span> Warm, playful, kid-friendly. Celebrates small wins. The glue that holds the family schedule together — and makes it fun. 🐝</li>
           </ul>
         </article>
 
@@ -328,15 +330,16 @@ footer a { color: var(--amber); }
               <p class="aka">aka Bos Streak</p>
             </div>
           </div>
-          <p class="role">Business strategy</p>
+          <p class="role">Business strategist &amp; product interrogator</p>
           <p class="description">
-            The boss who thinks big. Bluestreak handles business ideas, market analysis, and strategic
-            planning. When there's a decision to make about ventures or opportunities, Bluestreak weighs in.
+            The one who asks the hard questions. Bluestreak doesn't just analyze ideas — he stress-tests
+            them. Market research, competitive analysis, Business Model Canvas review. If your idea has
+            a weak spot, Bluestreak will find it before the market does.
           </p>
           <ul class="meta">
-            <li><span>Domain</span> Business strategy, market research, opportunity analysis</li>
-            <li><span>Tools</span> Web research, financial modeling, competitive analysis</li>
-            <li><span>Personality</span> Sharp and analytical. Sees the big picture. Not afraid to say "bad idea" when needed.</li>
+            <li><span>Domain</span> Business strategy, idea validation, market research, product interrogation</li>
+            <li><span>Tools</span> Web research, competitive analysis, financial modeling</li>
+            <li><span>Personality</span> Analytical and direct. "Why?" is his favorite question. Kills bad ideas early — not to discourage, but because honest feedback beats false hope.</li>
           </ul>
         </article>
 
@@ -368,15 +371,16 @@ footer a { color: var(--amber); }
               <p class="aka">aka Gus Al</p>
             </div>
           </div>
-          <p class="role">Workplace monitoring</p>
+          <p class="role">Security Director</p>
           <p class="description">
-            The vigilant guardian. Red Alert watches over production systems while the team sleeps —
-            monitoring alerts, checking logs, and flagging anything that needs attention before morning.
+            The vigilant guardian. Red Alert watches over workplace infrastructure while the team sleeps —
+            reviewing pull requests, flagging security issues, and preparing morning briefings so nothing
+            slips through before you even open your laptop.
           </p>
           <ul class="meta">
-            <li><span>Domain</span> Production monitoring, incident detection, overnight coverage</li>
-            <li><span>Tools</span> System monitoring, log analysis, alert management</li>
-            <li><span>Personality</span> Always alert (obviously). Calm under pressure. Knows when to escalate and when to handle it quietly.</li>
+            <li><span>Domain</span> Code security, PR review, incident detection, overnight coverage</li>
+            <li><span>Tools</span> GitHub, log analysis, security scanning, alert management</li>
+            <li><span>Personality</span> Cautious and meticulous. Assumes threats until proven safe. Calm under pressure — read-only by default, never touches production.</li>
           </ul>
         </article>
 


### PR DESCRIPTION
## Summary

Fixes four bot description accuracy issues found during an audit of SOUL.md files vs the live site.

Closes #8, closes #9, closes #10, closes #11

## Changes

### 🚨 Red Alert (fixes #8)
- **Role:** "Workplace monitoring" → "Security Director" (matches SOUL.md: *Security Director & Workplace Night Watch*)
- **Description:** Updated to reflect PR review + security focus, not just system monitoring
- **Tools:** Added GitHub (primary tool for PR reviews)

### 🚔 Prowl (fixes #9)
- **Role:** "Career, finances & fitness" → "Personal life: finances & fitness" (career isn't Prowl's domain)
- **Tools:** WRONG: Gmail, Google Calendar → CORRECT: Obsidian + Actual Budget
- **Description:** Rewritten to match SOUL.md: pattern-watching, gentle nudging, quiet when on track

### 🐝 Bumblebee (fixes #10)
- **Role:** Updated to "Family helper & kids companion"
- **Missing context added:**
  - Speaks English (Najmi & Isa's language)
  - Everything is kid-friendly
  - Has Obsidian access for kids' notes (Najmi & Isa)

### 🎯 Bluestreak (fixes #11)
- **Role:** Updated to "Business strategist & product interrogator"
- **Personality:** Now reflects "stress-test" and "challenge assumptions" identity from SOUL.md
- **Description:** Emphasizes asking hard questions and killing bad ideas early

## Testing
Visual review of the page — descriptions now match SOUL.md configurations.