### PR TITLE
chore: add Destructive Command Guard workflow

### DIFF
--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: Dicklesworthstone/destructive_command_guard/action@v0
+      - uses: Dicklesworthstone/destructive_command_guard/action@v0.4.5
         with:
           paths: .
           fail-on: error

--- a/.github/workflows/destructive-command-guard.yml
+++ b/.github/workflows/destructive-command-guard.yml
@@ -1,0 +1,19 @@
+name: Destructive Command Guard
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Dicklesworthstone/destructive_command_guard/action@v0
+        with:
+          paths: .
+          fail-on: error
+          format: markdown
+          comment-on-pr: false


### PR DESCRIPTION
Adds a conservative Destructive Command Guard scan to CI.\n\n- Runs on push and pull_request\n- Scans the full repository\n- Fails only on error findings\n- Leaves PR comments disabled to avoid noisy automation