### PR TITLE
viz: refresh architecture tooling wording

### DIFF
--- a/viz/architecture.html
+++ b/viz/architecture.html
@@ -1298,11 +1298,11 @@ flowchart TD
     <div style="margin-top: 20px;" class="card-grid-3">
       <div class="ve-card" style="--i:3; border-top: 3px solid var(--accent-bright);">
         <div style="font-weight: 700; font-size: 14px; margin-bottom: 6px;">Fully Connected (13)</div>
-        <div style="font-size: 13px; color: var(--text-dim);">Optimus, Prowl, Wheeljack, Bumblebee, Bluestreak, Red Alert, Hound, Perceptor, Rewind, Jazz, Rivet, Alpha Trion, and claude-zainf are currently active in the shared mesh.</div>
+        <div style="font-size: 13px; color: var(--text-dim);">Optimus, Prowl, Wheeljack, Bumblebee, Bluestreak, Red Alert, Hound, Perceptor, Rewind, Jazz, Rivet, Alpha Trion, and claude-zainf remain active in the shared mesh.</div>
       </div>
       <div class="ve-card" style="--i:4; border-top: 3px solid var(--amber);">
         <div style="font-weight: 700; font-size: 14px; margin-bottom: 6px;">Tool Layer</div>
-        <div style="font-size: 13px; color: var(--text-dim);">Amp, Codex CLI, OpenCode, and GPT-5.4 sessions form the implementation layer behind coding and ops execution.</div>
+        <div style="font-size: 13px; color: var(--text-dim);">Amp, Codex CLI, OpenCode, and GPT-5.5/OpenClaw sessions form the implementation layer behind coding and ops execution.</div>
       </div>
       <div class="ve-card" style="--i:5; border-top: 3px solid var(--rose);">
         <div style="font-weight: 700; font-size: 14px; margin-bottom: 6px;">Air-Gapped</div>


### PR DESCRIPTION
## Summary
- update architecture page wording for the current GPT-5.5/OpenClaw tooling layer
- soften active-mesh wording while preserving the roster/count

## Verification
- ran `git diff --check`