### PR TITLE
viz: add OpenClaw usage check to ops

### DIFF
--- a/viz/ops.html
+++ b/viz/ops.html
@@ -904,6 +904,14 @@
           Claude (Zain): 5h 0% | wk 0% | monthly budget available<br>Claude (BTA): 5h 0% | wk 10% (8% behind pace) | monthly budget available<br>Amp Free: 4.5% used, 95.5% remaining (resets hourly)<br>Codex (go): 13% primary | 17% weekly<br>Copilot Individual: 0.2% primary | 0% secondary
         </div>
       </div>
+
+      <div class="job-card job-card--error fade-up" style="animation-delay:0.15s">
+        <div class="job-header">
+          <div class="job-name">💸 OpenClaw Usage Check</div>
+          <span class="status-badge status-err">High</span>
+        </div>
+        <div class="job-desc">Last 2 days direct OpenClaw API usage is high: ~9.5k assistant messages and ~971M total tokens. Cost is dominated by GPT-5.5 (~81%) with GPT-5.4 second (~15%); Optimus is the largest agent share (~40%). Keep routing cheap/default work to Spark/free lanes where quality allows, and reserve GPT-5.5 for high-leverage turns.</div>
+      </div>
     </div>
 
 


### PR DESCRIPTION
## Summary
- add a public-safe OpenClaw usage check card to the Ops dashboard
- flag high 2-day direct API usage and dominant GPT-5.5 share

## Verification
- ran `python3 scripts/openclaw_usage.py --days 2`
- ran `node viz/build-index.js`
- ran `git diff --check`